### PR TITLE
fix: SSH+tmux session reconnection with claude lifecycle management

### DIFF
--- a/src/main/sshSessionManager.ts
+++ b/src/main/sshSessionManager.ts
@@ -97,20 +97,32 @@ export class SshSessionManager {
         // Build startup command:
         // 1. cd to project path if available
         // 2. Try tmux if available, otherwise plain shell
-        // 3. Auto-start claude CLI
+        // 3. Auto-start claude CLI (handles 3 cases: alive/dead/new)
         const projectPath = agent.projectPath || workspace.projects?.[0]?.path || workspace.path
-        const cdCmd = projectPath ? `cd ${JSON.stringify(projectPath)} 2>/dev/null; ` : ''
-        const claudeCmd = `claude`
+        const cdCmd = projectPath ? `cd ${JSON.stringify(projectPath)} 2>/dev/null && ` : ''
 
-        // tmux command with fallback: check if tmux exists first
+        // tmux command with claude lifecycle management:
+        // Case 1a: tmux session exists + claude alive → just attach (full session resume)
+        // Case 1b: tmux session exists + claude dead → restart with --continue (preserve conversation)
+        // Case 2:  no tmux session → create new + start claude
+        // Case 3:  tmux not installed → direct shell
         const tmuxCmd = [
           `if command -v tmux >/dev/null 2>&1; then`,
           `  tmux set-option -g window-size largest 2>/dev/null;`,
-          `  tmux has-session -t ${tmuxSessionName} 2>/dev/null`,
-          `  && tmux attach-session -t ${tmuxSessionName}`,
-          `  || tmux new-session -s ${tmuxSessionName} -x ${cols} -y ${rows};`,
+          `  if tmux has-session -t ${tmuxSessionName} 2>/dev/null; then`,
+          `    PANE_CMD=$(tmux display-message -t ${tmuxSessionName} -p '#{pane_current_command}' 2>/dev/null);`,
+          `    case "$PANE_CMD" in`,
+          `      bash|zsh|sh|fish|dash)`,
+          `        tmux send-keys -t ${tmuxSessionName} "${cdCmd}claude --continue" Enter;;`,
+          `    esac;`,
+          `    tmux attach-session -t ${tmuxSessionName};`,
+          `  else`,
+          `    tmux new-session -d -s ${tmuxSessionName} -x ${cols} -y ${rows};`,
+          `    tmux send-keys -t ${tmuxSessionName} "${cdCmd}claude" Enter;`,
+          `    tmux attach-session -t ${tmuxSessionName};`,
+          `  fi;`,
           `else`,
-          `  ${cdCmd}${claudeCmd};`,
+          `  ${cdCmd}claude;`,
           `fi`
         ].join(' ')
 


### PR DESCRIPTION
## Summary
- SSH+tmux接続が切断後に再接続すると、claudeプロセスが死んでいるためセッションが復帰できなかった問題を修正
- tmux内のclaude生存チェック（`pane_current_command`）を追加し、3パターンの再接続に対応:
  - **claude生存** → そのままattach（完全なセッション復帰）
  - **claude死亡** → `claude --continue`で会話を引き継いで再開
  - **tmuxセッションなし** → 新規作成 + claude自動起動
- tmux new-sessionでもclaudeが自動起動されるよう修正（以前はtmuxなし時のみ）

## Test plan
- [ ] SSHワークスペースを作成しエージェントを起動
- [ ] SSH接続を切断（ネットワーク断 or アプリ終了）
- [ ] 再接続時にtmuxセッションにreattachされることを確認
- [ ] claude生存時: そのまま操作継続できることを確認
- [ ] claude死亡時: `claude --continue`で会話が引き継がれることを確認
- [ ] tmuxなし環境: 従来通りclaudeが直接起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)